### PR TITLE
Update GAS_CONSUMPTION and minTonsForStorage values in JettonWallet contract

### DIFF
--- a/contracts/packages/mock/JettonWallet.tact
+++ b/contracts/packages/mock/JettonWallet.tact
@@ -63,8 +63,8 @@ trait JettonWallet {
     balance: Int;
     owner: Address;
     jetton_master: Address;
-    virtual const GAS_CONSUMPTION: Int = ton("0.05");
-    virtual const minTonsForStorage: Int = ton("0.05");
+    virtual const GAS_CONSUMPTION: Int = ton("0.01");
+    virtual const minTonsForStorage: Int = ton("0.01");
 
     //********************************************//
     //                  Messages                  //


### PR DESCRIPTION
This pull request updates the GAS_CONSUMPTION and minTonsForStorage values in the JettonWallet contract. The previous values were set to ton("0.05"), and this PR updates them to ton("0.01"). This change ensures more accurate calculations and improves the efficiency of the contract.